### PR TITLE
fix: 열린세션리스트조회순환참조문제해결

### DIFF
--- a/src/main/java/com/cpu/cams/InitData.java
+++ b/src/main/java/com/cpu/cams/InitData.java
@@ -56,11 +56,11 @@ public class InitData {
         activityService.updateStatus(1L, "STARTED");
 
         // test1 테스트활동1, 테스트활동2 참가
-        participantsService.addParticipant(activity1.getId(), member1Id);
-        participantsService.addParticipant(activity2.getId(), member1Id);
+        participantsService.addParticipant(activity1.getId(), member2Id);
+        participantsService.addParticipant(activity2.getId(), member2Id);
 
         // test2 테스트활동1 참가
-        participantsService.addParticipant(activity1.getId(), member2Id);
+        participantsService.addParticipant(activity1.getId(), member3Id);
 
     }
 }

--- a/src/main/java/com/cpu/cams/activity/entity/Activity.java
+++ b/src/main/java/com/cpu/cams/activity/entity/Activity.java
@@ -3,6 +3,7 @@ package com.cpu.cams.activity.entity;
 import com.cpu.cams.activity.dto.request.ActivityRequest;
 import com.cpu.cams.attendence.entity.Session;
 import com.cpu.cams.member.entity.Member;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -47,6 +48,7 @@ public class Activity {
     @Column(nullable = true)
     private String notes;
 
+    // 활동 신청 시작 전, 신청 진행 중, 신청 마감
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private ActivityStatus activityStatus = ActivityStatus.NOT_STARTED;

--- a/src/main/java/com/cpu/cams/attendence/controller/SessionController.java
+++ b/src/main/java/com/cpu/cams/attendence/controller/SessionController.java
@@ -2,6 +2,7 @@ package com.cpu.cams.attendence.controller;
 
 import com.cpu.cams.activity.entity.ActivityStatus;
 import com.cpu.cams.attendence.dto.request.SessionRequest;
+import com.cpu.cams.attendence.dto.response.OpenSessionResponse;
 import com.cpu.cams.attendence.entity.Session;
 import com.cpu.cams.attendence.service.SessionService;
 import lombok.RequiredArgsConstructor;
@@ -28,9 +29,9 @@ public class SessionController {
     // 내가 신청한 활동 중 세션이 열린 활동 리스트 조회
     // todo: memberId 안건네줘도 되지않나?
     @GetMapping("/{memberId}/open-session")
-    public ResponseEntity<Page<Session>> getOpenSessionList(@PathVariable Long memberId) {
+    public ResponseEntity<Page<OpenSessionResponse>> getOpenSessionList(@PathVariable Long memberId) {
 
-        Page<Session> result = sessionService.findOpenSessionList(memberId);
+        Page<OpenSessionResponse> result = sessionService.findOpenSessionList(memberId);
 
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/cpu/cams/attendence/dto/response/OpenSessionResponse.java
+++ b/src/main/java/com/cpu/cams/attendence/dto/response/OpenSessionResponse.java
@@ -1,5 +1,10 @@
 package com.cpu.cams.attendence.dto.response;
 
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
 public class OpenSessionResponse {
     private Long sessionId;
     private String activityTitle;

--- a/src/main/java/com/cpu/cams/attendence/entity/Session.java
+++ b/src/main/java/com/cpu/cams/attendence/entity/Session.java
@@ -30,9 +30,6 @@ public class Session {
 
     @Column(nullable = false)
     private Boolean openAttendance; // 출석 열렸는지 확인
-    
-    @Enumerated() // todo: 이거해야함
-    private ActivityStatus activityStatus;
 
     // == 연관관계 == //
     @ManyToOne(fetch = FetchType.LAZY)
@@ -54,9 +51,8 @@ public class Session {
         session.addActivity(activity);
         session.sessionNumber = sessionNumber;
         session.description = description;
-        session.attendancesCode = attendancesCode;
-        session.openAttendance = false;
-
+        session.attendancesCode = attendancesCode; // 클라이언트에서 생성되고 보내진 출석 코드
+        session.openAttendance = true; // 세션 생성 시 바로 출석 오픈
         return session;
     }
 

--- a/src/main/java/com/cpu/cams/attendence/service/SessionService.java
+++ b/src/main/java/com/cpu/cams/attendence/service/SessionService.java
@@ -4,6 +4,7 @@ import com.cpu.cams.activity.entity.Activity;
 import com.cpu.cams.activity.repository.ActivityRepository;
 import com.cpu.cams.attendence.SessionRepository;
 import com.cpu.cams.attendence.dto.request.SessionRequest;
+import com.cpu.cams.attendence.dto.response.OpenSessionResponse;
 import com.cpu.cams.attendence.entity.Attendance;
 import com.cpu.cams.attendence.entity.Session;
 import lombok.RequiredArgsConstructor;
@@ -26,12 +27,12 @@ public class SessionService {
     public Long createSession(Long activityId, SessionRequest request) {
 
         Activity activity = activityRepository.findById(activityId).orElseThrow(() -> new RuntimeException("활동 없는데?"));
-        // TODO 세션에 따른 모든 참여 학생 attendance 객체 생성
         // 세션 만들기
         Session session = Session.create(activity, request.getSessionNumber(), request.getDescription(), request.getAttendanceCode());
 
         Session saveSession = sessionRepository.save(session);
 
+        // 세션에 따른 모든 참여 학생 attendance 객체 생성
         // 학생에 따른 출석부 만들기 -> 더티채킹으로 repository 없이 만들기
         List<Attendance> attendanceList = activity.getParticipants().stream().map(participant -> Attendance.create(saveSession, participant)).toList();
 
@@ -39,13 +40,20 @@ public class SessionService {
     }
 
     // 열린 세션 확인하기
-    public Page<Session> findOpenSessionList(Long memberId) {
+    public Page<OpenSessionResponse> findOpenSessionList(Long memberId) {
         // memberId -> activity_partipants에서 activity조회해서 그 중에 session이 start인걸 조회한다~ 리턴값으로는 activity, session 둘 다 줘야 한다.
         // 1. memberId로 activity 찾기
         // 2. activity들 session 찾기
         // 3. session의 openAttendance true인 것 찾기
         PageRequest pageRequest = PageRequest.of(0, 3);
-        Page<Session> openSessionList = sessionRepository.findOpenSessionList(memberId, pageRequest);
+        Page<OpenSessionResponse> openSessionList = sessionRepository.findOpenSessionList(memberId, pageRequest).map(
+                session -> OpenSessionResponse.builder()
+                            .sessionId(session.getId())
+                            .activityTitle(session.getActivity().getTitle())
+                            .sessionNumber(session.getSessionNumber())
+                            .build());
         return openSessionList;
     }
+    
+    // 출석하기
 }

--- a/src/main/java/com/cpu/cams/member/entity/Member.java
+++ b/src/main/java/com/cpu/cams/member/entity/Member.java
@@ -4,6 +4,7 @@ import com.cpu.cams.activity.entity.Activity;
 import com.cpu.cams.activity.entity.ActivityParticipant;
 import com.cpu.cams.member.dto.request.SignupRequest;
 import com.cpu.cams.point.entity.Point;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] Feat : 새로운 기능 추가

-[] Bug : 버그 발견

-[x] Fix : 버그 수정

-[] Docs : 문서 수정

-[] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우

-[] Refactor : 코드 리펙토링

### 반영 브랜치
ex) fix/session-error-> main

### 변경 사항
열린 세션 리스트 조회 시 순환 개설자-개설활동 순환 참조 문제 해결
엔티티를 직접 반환하였는데, DTO로 반환하게 함으로써 해결했습니다.

### 테스트 결과
POSTMAN 테스트 결과 정상 동작