### PR TITLE
feat: 세션 완전 종료 기능 구현

### DIFF
--- a/src/main/java/com/cpu/cams/attendence/entity/Session.java
+++ b/src/main/java/com/cpu/cams/attendence/entity/Session.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -34,6 +35,10 @@ public class Session {
 
     @Column
     private LocalDateTime closedAt; // 마감 시간
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 
     // == 연관관계 == //
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/cpu/cams/attendence/entity/SessionStatus.java
+++ b/src/main/java/com/cpu/cams/attendence/entity/SessionStatus.java
@@ -1,5 +1,5 @@
 package com.cpu.cams.attendence.entity;
 
 public enum SessionStatus {
-    OPEN, CLOSED
+    OPEN, CLOSED, FINISHED
 }

--- a/src/main/java/com/cpu/cams/attendence/repository/SessionRepository.java
+++ b/src/main/java/com/cpu/cams/attendence/repository/SessionRepository.java
@@ -28,4 +28,6 @@ public interface SessionRepository extends JpaRepository<Session, Long> {
     List<Session> findByStatusAndClosedAtBefore(SessionStatus status, LocalDateTime time);
 
     Page<Session> findByActivityId(Long activityId, Pageable pageable);
+
+    List<Session> findByStatusNotAndCreatedAtBefore(SessionStatus status, LocalDateTime time);
 }


### PR DESCRIPTION
- sessionStatus에 FINISHED 추가
- FINISHED 변경 시 해당 세션은 완전 종료 -> 새로운 출석 오픈할 수 있음
- CLOSED 상태에서는 세션 정보 (출석 코드, 마감 시간) 변경 가능
- 세션 생성 후 3시간 경과 시 자동으로 FINISHED로 변경